### PR TITLE
Allow other drops.

### DIFF
--- a/custom-hotbar.js
+++ b/custom-hotbar.js
@@ -291,20 +291,18 @@ export class CustomHotbar extends Hotbar {
     //only needs to be done when dropping an item onto the Custom Hotbar.
     //revert once assign custom macro complete
     CHBDebug("Custom Hotbar | Dropped type:", data.type);
-    if (data.type == "Item" || data.type =="RollTable") {
-      CHBDebug("Custom Hotbar | Attempting monkey hotpatch!");
-      let coreAssignHotbarMacro = game.user.assignHotbarMacro;
-      game.user.assignHotbarMacro = this.assignCustomHotbarMacro.bind(this); 
-      Hooks.once("customHotbarAssignComplete", () => game.user.assignHotbarMacro = coreAssignHotbarMacro);
-  
-      //does this need to be set to false when done?
-      if ( await Hooks.call("hotbarDrop", this, data, customSlot) === undefined ) {
-        CHBDebug("Custom Hotbar | hotbarDrop not found, reverting monkey hotpatch!")
-        game.user.assignHotbarMacro = coreAssignHotbarMacro; 
-        return; 
-      } else {
-        CHBDebug("Custom Hotbar | hotbarDrop true");
-      }
+    CHBDebug("Custom Hotbar | Attempting monkey hotpatch!");
+    let coreAssignHotbarMacro = game.user.assignHotbarMacro;
+    game.user.assignHotbarMacro = this.assignCustomHotbarMacro.bind(this); 
+    Hooks.once("customHotbarAssignComplete", () => game.user.assignHotbarMacro = coreAssignHotbarMacro);
+
+    //does this need to be set to false when done?
+    if ( await Hooks.call("hotbarDrop", this, data, customSlot) === undefined ) {
+      CHBDebug("Custom Hotbar | hotbarDrop not found, reverting monkey hotpatch!")
+      game.user.assignHotbarMacro = coreAssignHotbarMacro; 
+      return; 
+    } else {
+      CHBDebug("Custom Hotbar | hotbarDrop true");
     }
 
     // Only handles Macro drops


### PR DESCRIPTION
When dropping an entity onto the hotbar only items and rolltables are handled and other types are dropped silently.

In systems other than DnD5e it is possible do drag other types from the sheet (e.g. abilities and other rollable elements from the sheets). All these are handled system agnostic by the foundry hotbar and delegated back to the system to create a macro.

By removing this restriction the custom bar behaves like the foundry hotbar and delegates the call as well (at least in my game with the system DCC which uses various other types).

If you think it is feasible to support this behaviour - this is the change I did.